### PR TITLE
Fix code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/api/accounts.mjs
+++ b/api/accounts.mjs
@@ -128,8 +128,8 @@ router.get("/user", async (req, res, next) => {
                 username = username.substring(1);
             }
             const user = await db.collection("users").findOne({
-                username: username,
-                discriminator: discriminator,
+                username: { $eq: username },
+                discriminator: { $eq: discriminator },
             });
 
             if (user === null) {


### PR DESCRIPTION
Fixes [https://github.com/6TELOIV/grotto-bestiary/security/code-scanning/3](https://github.com/6TELOIV/grotto-bestiary/security/code-scanning/3)

To fix the problem, we need to ensure that the user input is properly sanitized before being used in the database query. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
